### PR TITLE
Improved error handling

### DIFF
--- a/src/com/zink/fly/kit/FlyFactory.java
+++ b/src/com/zink/fly/kit/FlyFactory.java
@@ -17,10 +17,11 @@
 
 package com.zink.fly.kit;
 
-import com.zink.fly.*;
+import com.zink.fly.FieldCodec;
+import com.zink.fly.Fly;
+import com.zink.fly.FlyAccessException;
 import com.zink.fly.stub.FlyStub;
 import com.zink.fly.stub.SerializingFieldCodec;
-import java.net.ConnectException;
 
 
 /**
@@ -54,7 +55,7 @@ public class FlyFactory  {
         Fly stub = null;
         try {
             stub =  new FlyStub(host, fieldCodec);
-        } catch (ConnectException ex) {
+        } catch (Exception ex) {
             throw new FlyAccessException("No Fly Server running on ["+host+"]",ex);
         }
         return stub;   

--- a/src/com/zink/fly/kit/FlyFinder.java
+++ b/src/com/zink/fly/kit/FlyFinder.java
@@ -84,18 +84,25 @@ public class FlyFinder  {
             if (!reps.isEmpty()) {
                 FlyServerRep rep = (FlyServerRep)reps.toArray()[0];
                 fly = new FlyStub(rep.getFlyAddr(), fieldCodec);
-            }    
+            }
         } catch (Exception ex) {
            throw new FlyAccessException(ex);
         } finally {
            cache.terminate();
         }
-        
-        return fly;   
-    }      
-       
-    
-    /**
+
+        postCheck(fly);
+
+        return fly;
+    }
+
+    private void postCheck(Fly fly) {
+        if (fly == null) {
+            throw new FlyAccessException("Cannot find Fly");
+        }
+    }
+
+	/**
      * Find a Fly instance on the local sub net that mathces the tag supplied 
      * in the array of tags supplied. 
      * 
@@ -139,6 +146,9 @@ public class FlyFinder  {
         } finally {
             cache.terminate();
         }
+
+        postCheck(fly);
+
         return fly;
     }
 }

--- a/src/com/zink/fly/stub/FlyStub.java
+++ b/src/com/zink/fly/stub/FlyStub.java
@@ -22,7 +22,7 @@ import com.zink.fly.FieldCodec;
 import com.zink.fly.Fly;
 import com.zink.fly.Notifiable;
 import com.zink.fly.NotifyHandler;
-import java.net.ConnectException;
+
 import java.net.InetAddress;
 import java.util.Collection;
 
@@ -39,14 +39,14 @@ public class FlyStub implements Fly  {
 
 
     
-    public FlyStub(String hostname, FieldCodec fieldCodec) throws ConnectException
+    public FlyStub(String hostname, FieldCodec fieldCodec)
         {
         Remoter remoter = new Remoter(hostname,FLY_PORT);
         codec = new MethodCodec(remoter, fieldCodec);
         }
 
     
-    public FlyStub(InetAddress addr, FieldCodec fieldCodec) throws ConnectException
+    public FlyStub(InetAddress addr, FieldCodec fieldCodec)
         {
         Remoter remoter = new Remoter(addr,FLY_PORT);
         codec = new MethodCodec(remoter, fieldCodec);

--- a/src/com/zink/fly/stub/Remoter.java
+++ b/src/com/zink/fly/stub/Remoter.java
@@ -19,11 +19,11 @@ package com.zink.fly.stub;
 
 import com.zink.fly.FlyAccessException;
 import com.zink.fly.Notifiable;
+
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.ConnectException;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.util.concurrent.BlockingQueue;
@@ -54,22 +54,22 @@ public class Remoter {
     private NotifyMessageDispatcher notifyDispatcher;
 
     
-    public Remoter(String hostName, int port) throws ConnectException {
+    public Remoter(String hostName, int port) {
         try {
             initStreams(new Socket(hostName, port));
             new MessageListener().start();
         } catch (Exception exp) {
-            throw new ConnectException("Failed connection to Fly on "+ hostName + ":" + port);
+            throw new FlyAccessException("Failed connection to Fly on "+ hostName + ":" + port, exp);
         }
     }
     
   
-    public Remoter(InetAddress hostAddr, int port) throws ConnectException {
+    public Remoter(InetAddress hostAddr, int port) {
         try {
             initStreams(new Socket(hostAddr, port));
             new MessageListener().start();
         } catch (Exception exp) {
-            throw new ConnectException("Failed connection to Fly on "+ hostAddr.getHostName() + ":" + port);
+            throw new FlyAccessException("Failed connection to Fly on "+ hostAddr.getHostName() + ":" + port, exp);
         }
     }
     


### PR DESCRIPTION
Some of this is a bit rough-and-ready - you may want to keep using ConnectionException - but I was able to track down (well, sort of) proxy config problems much more easily once I'd changed the code so that:

(a) If it can't find a Fly server, FlyFinder throws an exception (rather than returning null)
(b) FlyFactory throws a FlyAccessException (so that it can attach the cause of the error)

Regards,

TS
